### PR TITLE
Fixed extension not working for Windows

### DIFF
--- a/src/process.ts
+++ b/src/process.ts
@@ -17,8 +17,8 @@ export function createBustedProcess(
     uri: vscode.Uri
 ) {
     const program = context.globalState.get('program', 'busted');
-    const args = [uri.path, ...executionArguments(mode)];
-    const options = { 'cwd': workspace.uri.path };
+    const args = [uri.fsPath, ...executionArguments(mode)];
+    const options = { 'cwd': workspace.uri.fsPath };
 
     return spawn(program, args, options);
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -28,7 +28,7 @@ export function tokenizePath(
 ) {
     const root = path.dirname(workspace.uri.path);
     const relativePath = path.relative(root, uri.path);
-    const tokens = relativePath.split("/");
+    const tokens = relativePath.split(path.sep);
 
     return { root, tokens };
 }


### PR DESCRIPTION
The extension wasn't working on my Windows computer, and I tracked down the error to an issue with how a test file's path is parsed in `utils.tokenizePath()`. Essentially, `path.relative` returns a string that uses platform-specific separators instead of just forward slash `/`, which caused the split along the path separator to break. I fixed it by replacing the hard-coded `/` char with `path.sep`.

Let me know if this breaks anything on Linux 😄